### PR TITLE
Refactored tool interaction for Q key and popup menu

### DIFF
--- a/src/components/hud/game-hud.ts
+++ b/src/components/hud/game-hud.ts
@@ -345,8 +345,24 @@ export class GameHudComponent extends HTMLElement {
     private handleToolClick(event: MouseEvent): void {
         const target = (event.target as HTMLElement).closest('.tool-option') as HTMLElement | null;
         if (target && target.dataset.tool) {
-            this.equipTool(target.dataset.tool as Tool);
-            this.hideToolPopup();
+            const toolId = target.dataset.tool as Tool;
+            // Dispatch an event so the game logic can handle the state change
+            this.dispatchEvent(new CustomEvent('tool-selected', {
+                detail: { toolId },
+                bubbles: true, // Allows the event to bubble up if needed
+                composed: true // Allows the event to cross shadow DOM boundaries
+            }));
+            // The game logic will be responsible for hiding the popup now
+            // this.hideToolPopup();
+        }
+    }
+
+    public setActiveTool(toolId: Tool): void {
+        const newIndex = this.tools.findIndex(t => t.id === toolId);
+        if (newIndex !== -1) {
+            // This is a direct set, do not modify lastUsedToolIndex here.
+            this.currentToolIndex = newIndex;
+            this.updateCurrentToolDisplay();
         }
     }
 


### PR DESCRIPTION
This implements a new way to interact with tools using the 'Q' key:
- A short press of 'Q' will switch to the next available tool.
- A long press of 'Q' will bring up a tool selection popup, allowing you to choose with the mouse.

Key changes include:
- Modified `InputHandler.ts` to distinguish between short and long presses of the 'Q' key. This replaces the previous 'Tab' key functionality for showing the popup.
- Updated `game.ts` to handle new input callbacks, manage pointer lock when the popup is shown or hidden, and ensure the game state remains consistent.
- Refactored how tools are selected from the HUD (`game-hud.ts` and `game.ts`). It now uses an event-driven approach, making `GameState` the definitive source for which tool is equipped.
- Ensured that your 3D tool model (like the pickaxe or axe) updates correctly when a tool is selected from the popup menu, just like it does when you quickly toggle tools.
- Addressed issues where your movement could get stuck and pointer lock wasn't managed correctly after interacting with the popup.