### PR TITLE
Refactor: Change action hotkey from 'e' to left-click

### DIFF
--- a/src/game/InputHandler.ts
+++ b/src/game/InputHandler.ts
@@ -60,6 +60,7 @@ class InputHandler {
         document.addEventListener('keydown', (e) => this.onKeyDown(e));
         document.addEventListener('keyup', (e) => this.onKeyUp(e));
         document.addEventListener('mousemove', (e) => this.onMouseMove(e));
+        document.addEventListener('click', (e) => this.onMouseClick(e)); // Added this line
         window.addEventListener('resize', () => this.onWindowResize());
 
         document.getElementById('game-container')?.addEventListener('click', () => {
@@ -139,8 +140,6 @@ class InputHandler {
 
         this.gameState.setKeyPressed(key, true);
 
-        if (key === 'e') this.callbacks.onAction?.();
-
         // 'q' key long press logic
         if (key === 'q') {
             if (!this.qKeyTimer) { // Only start a new timer if one isn't already running
@@ -208,6 +207,19 @@ class InputHandler {
 
     private onWindowResize(): void {
         this.callbacks.onWindowResize?.();
+    }
+
+    private onMouseClick(event: MouseEvent): void {
+        // Check for left click (button === 0)
+        if (event.button !== 0) return;
+
+        if (
+            this.gameState.pointerLocked &&
+            !this.gameState.isPaused &&
+            !this.gameState.isInteracting
+        ) {
+            this.callbacks.onAction?.();
+        }
     }
 
     private async handleGeminiSubmit(): Promise<void> {


### PR DESCRIPTION
This commit changes the primary action input from the 'e' key to a left mouse click.

- Modified `InputHandler.ts` to remove the 'e' key listener for actions and added a new event listener for 'click'.
- The `onAction` callback is now triggered on left-click when the pointer is locked and the game is not paused or in an interaction state.
- Confirmed that `game.ts` requires no changes as the existing callback system handles the input source abstraction.
- Manual testing confirmed that left-click initiates actions as expected, and the 'e' key no longer does.