### PR TITLE
feat: Make inventory panel visible by default

### DIFF
--- a/src/components/hud/game-hud.ts
+++ b/src/components/hud/game-hud.ts
@@ -157,7 +157,7 @@ hudTemplate.innerHTML = `
       border-radius: 10px;
       padding: 15px;
       color: white;
-      display: none; /* Hidden by default */
+      display: block; /* Visible by default */
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     }
     #inventory-panel h3 {

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -76,7 +76,7 @@ class GameState {
     public isPaused: boolean = false;
     public isInteracting: boolean = false;
     public isToolPopupVisible: boolean = false; // <-- ADD THIS LINE
-    public isInventoryVisible: boolean = false;
+    public isInventoryVisible: boolean = true;
     public actionProgress: number = 0;
     public currentActionTarget: ActionTarget | null = null;
 

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -97,6 +97,11 @@ class Game {
 
         await this.uiManager.init(uiManagerCallbacks);
 
+        // Populate inventory if it's visible by default
+        if (this.gameState.isInventoryVisible) {
+            this.uiManager.setInventory(this.gameState.getStructuredInventory());
+        }
+
         // --- FIX STARTS HERE ---
         // Manually and proactively show the loading screen.
         // This guarantees it is visible while the rest of the game initializes.


### PR DESCRIPTION
- Changed CSS in game-hud.ts to display inventory panel by default.
- Updated GameState.isInventoryVisible to be true by default.
- Ensured game.ts populates inventory on initialization if visible.